### PR TITLE
Update name.rb: insert a space after %

### DIFF
--- a/lib/unicode/name.rb
+++ b/lib/unicode/name.rb
@@ -18,7 +18,7 @@ module Unicode
 
       INDEX[:CP_RANGES].each{|prefix, range|
         if range.any?{ |range| codepoint >= range[0] && codepoint <= range[1] }
-          return "%s%.4X" %[prefix, codepoint]
+          return "%s%.4X" % [prefix, codepoint]
         end
       }
 


### PR DESCRIPTION
ruby -w -r unicode/name -e "Unicode::Name.of 'a'"
causes:

/Users/XXXX/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/unicode-name-1.13.3/lib/unicode/name.rb:21: warning: `%' after local variable or literal is interpreted as binary operator
/Users/XXXX/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/unicode-name-1.13.3/lib/unicode/name.rb:21: warning: even though it seems like string literal